### PR TITLE
Update virions and v1.16 protocol changes

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -7,7 +7,7 @@ projects:
     - "resources/github"
     libs:
     - src: CortexPE/Commando/Commando
-      version: ^0.3.1
+      version: ^2.1.1
     - src: muqsit/invmenu/InvMenu
-      version: ^2.1.0
+      version: ^4.0.0
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: Backpack
 main: xenialdan\Backpack\Loader
 version: 0.2.0
-api: [3.9.3]
+api: [3.14.0]
 author: XenialDan
 softdepend: [DEVirion]
 extensions: ["gd"]

--- a/src/xenialdan/Backpack/BackpackEntity.php
+++ b/src/xenialdan/Backpack/BackpackEntity.php
@@ -39,7 +39,7 @@ class BackpackEntity extends Human
         parent::sendSpawnPacket($player);
         if ($this->getOwningEntityId() !== null && $this->getOwningEntity()->getGenericFlag(self::DATA_FLAG_CHESTED)) {
             $pk = new SetActorLinkPacket();
-            $pk->link = new EntityLink($this->getOwningEntityId(), $this->getId(), EntityLink::TYPE_PASSENGER, true);
+            $pk->link = new EntityLink($this->getOwningEntityId(), $this->getId(), EntityLink::TYPE_PASSENGER, true, false);
             $player->sendDataPacket($pk);
         }
     }

--- a/src/xenialdan/Backpack/BackpackInventory.php
+++ b/src/xenialdan/Backpack/BackpackInventory.php
@@ -33,10 +33,10 @@ class BackpackInventory extends InvMenuInventory
 
 	public function onClose(Player $who) : void
 	{
-		parent::onClose($who);
 		if (count($this->getViewers()) === 1 and $this->getHolder()->isValid()) {
 			$this->getHolder()->getLevelNonNull()->broadcastLevelSoundEvent($this->getHolder()->add(0.5, 0.5, 0.5), $this->getCloseSound());
 		}
+		parent::onClose($who);
 	}
 
 	protected function getOpenSound(): int

--- a/src/xenialdan/Backpack/BackpackInventory.php
+++ b/src/xenialdan/Backpack/BackpackInventory.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace xenialdan\Backpack;
 
-use muqsit\invmenu\inventories\ChestInventory;
+use muqsit\invmenu\inventory\InvMenuInventory;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\Player;
 
-class BackpackInventory extends ChestInventory
+class BackpackInventory extends InvMenuInventory
 {
 	/** @var Backpack */
 	private $vault_data;
@@ -22,9 +23,20 @@ class BackpackInventory extends ChestInventory
 		return $this->vault_data;
 	}
 
-	public function getName(): string
+	public function onOpen(Player $who) : void
 	{
-		return "Backpack";
+		parent::onOpen($who);
+		if (count($this->getViewers()) === 1 and $this->getHolder()->isValid()) {
+			$this->getHolder()->getLevelNonNull()->broadcastLevelSoundEvent($this->getHolder()->add(0.5, 0.5, 0.5), $this->getOpenSound());
+		}
+	}
+
+	public function onClose(Player $who) : void
+	{
+		parent::onClose($who);
+		if (count($this->getViewers()) === 1 and $this->getHolder()->isValid()) {
+			$this->getHolder()->getLevelNonNull()->broadcastLevelSoundEvent($this->getHolder()->add(0.5, 0.5, 0.5), $this->getCloseSound());
+		}
 	}
 
 	protected function getOpenSound(): int

--- a/src/xenialdan/Backpack/BackpackMenuMetadata.php
+++ b/src/xenialdan/Backpack/BackpackMenuMetadata.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xenialdan\Backpack;
+
+use muqsit\invmenu\inventory\InvMenuInventory;
+use muqsit\invmenu\metadata\SingleBlockMenuMetadata;
+
+class BackpackMenuMetadata extends SingleBlockMenuMetadata
+{
+	public function createInventory() : InvMenuInventory
+	{
+		return new BackpackInventory($this);
+	}
+}

--- a/src/xenialdan/Backpack/Commands.php
+++ b/src/xenialdan/Backpack/Commands.php
@@ -15,7 +15,6 @@ class Commands extends BaseCommand
 
 	/**
 	 * @throws \CortexPE\Commando\exception\ArgumentOrderException
-	 * @throws \CortexPE\Commando\exception\SubCommandCollision
 	 */
 	protected function prepare(): void
 	{


### PR DESCRIPTION
This PR updates Commando (to v2.1.1) and InvMenu (to v4.0.0) and supplies `causedByRider: false` parameter to `EntityLink` (v1.16).